### PR TITLE
Update postcss-url to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "postcss-nested": "^2.0.2",
     "postcss-reporter": "^4.0.0",
     "postcss-simple-vars": "^4.0.0",
-    "postcss-url": "^7.0.0",
+    "postcss-url": "^7.1.1",
     "rebem-css": "^0.2.0",
     "stylelint": "^7.7.1",
     "stylelint-config-standard": "^16.0.0",


### PR DESCRIPTION
Last version of `postcss-url` was have a bug with path without quotes. Now it was fixed: https://github.com/postcss/postcss-url/issues/105#issuecomment-317375906