### PR TITLE
Fix mistake in the page dependencies

### DIFF
--- a/common.blocks/page/page.deps.js
+++ b/common.blocks/page/page.deps.js
@@ -1,7 +1,7 @@
 ({
     shouldDeps: [
         {
-            mods: { view: ['404'] }
+            mods: { view: '404' }
         },
         'header',
         'body',


### PR DESCRIPTION
Если в mods одно значение, то оно должно быть вне массива.
Так описано тут: https://ru.bem.info/technologies/classic/deps-spec/#mods
И так у меня не правильно работает deps. Вместо зависимости от модификатора `view` со значением `404` он создаёт зависимость от `view` со значением `true`.